### PR TITLE
remove the comma

### DIFF
--- a/example.json
+++ b/example.json
@@ -4,6 +4,6 @@
             "Repo":"pabbix",
             "Branch":"master",
             "Shell":"date"
-        },
+        }
     ]
 }


### PR DESCRIPTION
It may breaks when you just copy example.json to config.json and run gohub.
