### PR TITLE
Invalid JSON in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ You want to track the status of your Repository "repo" and the branch master. If
 ```json
 {
     "Hooks":[
-        "Repo":"repo",
-        "Branch":"master",
-        "Shell":"niftyscript.sh"
+        {
+          "Repo":"repo",
+          "Branch":"master",
+          "Shell":"niftyscript.sh"
+        }
     ]
 }
 ```


### PR DESCRIPTION
Hi, I found a minor typo in the README file.  The hook object should be enclosed in curly braces.  The syntax in the example.json file distributed with the project is correct, but for some reason I copied the JSON from the README file and that's probably the only reason I noticed.
